### PR TITLE
Fixed erroneous import

### DIFF
--- a/src/app/pouchdb-service/pouchdb-adapter.ts
+++ b/src/app/pouchdb-service/pouchdb-adapter.ts
@@ -1,5 +1,5 @@
 declare function require(name: string);
-import PouchDB from 'pouchdb';
+import * as PouchDB from 'pouchdb';
 PouchDB.plugin(require('pouchdb-upsert'));
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 // import 'rxjs/add/observable/combineLatest';


### PR DESCRIPTION
import PouchDB from 'pouchdb';
will cause this error: 
Module '".../angular-cli-pouchdb-couchdb/node_modules/@types/pouchdb/index"' has no default export.

this will fix it : import * as PouchDB from 'pouchdb';
